### PR TITLE
Rename money transaction amount field from 'amount' to 'cad'

### DIFF
--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -156,7 +156,7 @@ export default function ExpenditureChart({
   // Find earliest transaction date after the cutoff
   const validDates: Date[] = [];
   data.forEach((transaction) => {
-    if (transaction.date && transaction.amount) {
+    if (transaction.date && transaction.cad) {
       const parsed = parseMoneyDate(transaction.date);
       if (parsed && !isNaN(parsed.getTime()) && parsed >= cutoffDate) {
         validDates.push(parsed);
@@ -197,7 +197,7 @@ export default function ExpenditureChart({
   });
 
   data.forEach((transaction) => {
-    if (!transaction.date || !transaction.amount) return;
+    if (!transaction.date || !transaction.cad) return;
 
     const moneyDate = parseMoneyDate(transaction.date);
 
@@ -206,7 +206,7 @@ export default function ExpenditureChart({
     if (moneyDate >= startDate && moneyDate <= endDate) {
       const weekKey = getWeekKey(moneyDate);
       const tag = transaction.tag || "Other";
-      const amount = parseFloat(transaction.amount.replace(/[^0-9.-]/g, ""));
+      const amount = parseFloat(transaction.cad.replace(/[^0-9.-]/g, ""));
 
       if (isNaN(amount) || amount === 0) return;
       if (tag === "Investments") return;

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -104,7 +104,7 @@ export type WorkoutData = {
 export type MoneyData = {
   date: string;
   name: string;
-  amount: string;
+  cad: string;
   tag: string;
   merchant: string;
 };
@@ -202,7 +202,7 @@ export async function fetchMoney(limit?: number): Promise<MoneyData[]> {
   return rows.map((row) => ({
     date: (row.Date as string) || "",
     name: (row.Name as string) || "",
-    amount: (row.Amount as string) || "",
+    cad: (row.CAD as string) || "",
     tag: (row.Tag as string) || "",
     merchant: (row.Merchant as string) || "",
   }));


### PR DESCRIPTION
## Summary
Renamed the `amount` field to `cad` in the MoneyData type and all related code to better reflect that the values represent Canadian dollars (CAD). This improves code clarity by making the currency explicit.

## Changes
- Updated `MoneyData` type definition in `lib/sheets.ts` to use `cad` instead of `amount`
- Updated `fetchMoney()` function to map the "CAD" column from the sheet to the `cad` field
- Updated all references in `ExpenditureChart.tsx` component to use `transaction.cad` instead of `transaction.amount`
- Updated amount parsing logic to reference the renamed field

## Details
This is a straightforward field rename that improves code readability by making the currency denomination explicit in the field name. All usages have been updated consistently across the codebase.

https://claude.ai/code/session_01WfMLeXdbUh6Aubx5Mef8Ra