### PR TITLE
Enforce dark mode and add custom 404 page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,9 +18,14 @@
   --text-4xl: 48px;
 }
 
+html {
+  color-scheme: dark;
+}
+
 body {
   font-family: var(--font-karla);
   color: #ffffff;
+  background-color: #000000;
 }
 
 .font-micro5 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,7 @@ export default async function RootLayout({
   await posthog.shutdown();
 
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body className={`${karla.variable} bg-black antialiased`}>
         <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col items-center px-6 md:px-16">
           <Header />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 py-16 text-center">
+      <h1 className="text-4xl font-bold">404</h1>
+      <p className="text-secondary text-lg">This page could not be found.</p>
+      <Link
+        href="/"
+        className="text-secondary hover:text-white transition-colors underline underline-offset-4"
+      >
+        Return home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
- Enforced dark mode styling across the entire site by applying the 'dark' class to the root element and setting the CSS color scheme.
- Implemented a custom 404 error page with consistent layout and theme styling.

[v0 Session](https://v0.app/chat/h58b9psnRn2)