### PR TITLE
Improve spending chart privacy with relative units and detailed tooltips

### DIFF
--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -72,7 +72,7 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
         <p className="text-secondary mb-2 text-xs">{label}</p>
         <div className="mb-2 flex items-center gap-2 border-b border-white/10 pb-2">
           <p className="text-secondary text-xs">Total:</p>
-          <p className="text-xs font-medium">${totalAmount.toFixed(2)}</p>
+          <p className="text-xs font-medium">{totalAmount.toFixed(1)}u</p>
         </div>
         {sortedPayload.map((entry, index) => {
           if (entry.value === 0) return null;
@@ -83,7 +83,7 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
                 style={{ backgroundColor: entry.color }}
               />
               <p className="text-secondary text-xs">{entry.name}:</p>
-              <p className="text-xs font-medium">${entry.value.toFixed(2)}</p>
+              <p className="text-xs font-medium">{entry.value.toFixed(1)}u</p>
             </div>
           );
         })}
@@ -260,9 +260,9 @@ export default function ExpenditureChart({
   return (
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
-        <p className="text-sm font-medium">Spending Trends</p>
+        <p className="text-sm font-medium">Spending Trends (relative)</p>
         <p className="text-secondary text-xs">
-          Avg: ${avgSpent.toFixed(2)}/week
+          Avg: {avgSpent.toFixed(1)}u/week
         </p>
       </div>
       <div className="min-h-[300px] flex-1">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -268,7 +268,7 @@ export default function ExpenditureChart({
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
         <p className="text-sm font-medium">Spending Trends</p>
-        <InfoTooltip content="Spending shown as proportional units to protect privacy. Bars indicate each category's % of total spend." />
+        <InfoTooltip content="▲ is our unit. Bars = % of total spend." />
       </div>
       <div className="min-h-[300px] flex-1">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -72,10 +72,11 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
         <p className="text-secondary mb-2 text-xs">{label}</p>
         <div className="mb-2 flex items-center gap-2 border-b border-white/10 pb-2">
           <p className="text-secondary text-xs">Total:</p>
-          <p className="text-xs font-medium">{totalAmount.toFixed(1)}u</p>
+          <p className="text-xs font-medium">{totalAmount.toFixed(1)}%</p>
         </div>
         {sortedPayload.map((entry, index) => {
           if (entry.value === 0) return null;
+          const percentage = totalAmount > 0 ? ((entry.value / totalAmount) * 100).toFixed(0) : "0";
           return (
             <div key={index} className="flex items-center gap-2">
               <div
@@ -83,7 +84,7 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
                 style={{ backgroundColor: entry.color }}
               />
               <p className="text-secondary text-xs">{entry.name}:</p>
-              <p className="text-xs font-medium">{entry.value.toFixed(1)}u</p>
+              <p className="text-xs font-medium">{percentage}%</p>
             </div>
           );
         })}
@@ -260,10 +261,7 @@ export default function ExpenditureChart({
   return (
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
-        <p className="text-sm font-medium">Spending Trends (relative)</p>
-        <p className="text-secondary text-xs">
-          Avg: {avgSpent.toFixed(1)}u/week
-        </p>
+        <p className="text-sm font-medium">Spending Trends</p>
       </div>
       <div className="min-h-[300px] flex-1">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import type { MoneyData } from "@/lib/sheets";
 import { SPENDING_COLORS } from "@/lib/colors";
+import InfoTooltip from "@/components/Home/InfoTooltip";
 
 type ExpenditureChartProps = {
   data: MoneyData[];
@@ -83,14 +84,14 @@ function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProp
                 style={{ backgroundColor: entry.color }}
               />
               <p className="text-secondary text-xs">{entry.name}:</p>
-              <p className="text-xs font-medium">{pct}%</p>
+              <p className="text-xs font-medium">{pct}▲</p>
             </div>
           );
         })}
         {grandTotal && grandTotal > 0 && (
           <div className="mt-2 flex items-center gap-2 border-t border-white/10 pt-2">
             <p className="text-secondary text-xs">Week total:</p>
-            <p className="text-xs font-medium">{((weekTotal / grandTotal) * 100).toFixed(1)}%</p>
+            <p className="text-xs font-medium">{((weekTotal / grandTotal) * 100).toFixed(1)}▲</p>
           </div>
         )}
       </div>
@@ -267,6 +268,7 @@ export default function ExpenditureChart({
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
         <p className="text-sm font-medium">Spending Trends</p>
+        <InfoTooltip content="Spending values are shown as proportional units relative to the median transaction — actual amounts are not displayed. Each bar segment shows what percentage of the total spend over the selected period comes from that category." />
       </div>
       <div className="min-h-[300px] flex-1">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -260,8 +260,6 @@ export default function ExpenditureChart({
     );
   }, 0);
 
-  const avgSpent = chartData.length > 0 ? totalSpent / chartData.length : 0;
-
   const moneyTagsArray = Array.from(moneyTags).sort();
 
   return (

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -268,7 +268,7 @@ export default function ExpenditureChart({
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
         <p className="text-sm font-medium">Spending Trends</p>
-        <InfoTooltip content="Spending values are shown as proportional units relative to the median transaction — actual amounts are not displayed. Each bar segment shows what percentage of the total spend over the selected period comes from that category." />
+        <InfoTooltip content="Spending shown as proportional units to protect privacy. Bars indicate each category's % of total spend." />
       </div>
       <div className="min-h-[300px] flex-1">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -268,7 +268,7 @@ export default function ExpenditureChart({
     <div className="flex h-full flex-col outline-none focus:outline-none">
       <div className="border-border flex h-14 items-center justify-between border-b px-4">
         <p className="text-sm font-medium">Spending Trends</p>
-        <InfoTooltip content="▲ is our unit. Bars = % of total spend." />
+        <InfoTooltip content="▲ = proportional unit. Each bar segment shows % of total period spend." />
       </div>
       <div className="min-h-[300px] flex-1">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -26,6 +26,7 @@ type CustomTooltipProps = {
     name: string;
   }>;
   label?: string;
+  grandTotal?: number;
 };
 
 type WeekData = {
@@ -62,21 +63,19 @@ function getWeekKey(date: Date): string {
   return startOfWeek.toISOString().split("T")[0];
 }
 
-function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
+function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProps) {
   if (active && payload && payload.length) {
     const sortedPayload = [...payload].sort((a, b) => b.value - a.value);
-    const totalAmount = payload.reduce((sum, entry) => sum + entry.value, 0);
+    const weekTotal = payload.reduce((sum, entry) => sum + entry.value, 0);
 
     return (
       <div className="border-border flex flex-col border bg-black px-3 py-2 text-sm">
         <p className="text-secondary mb-2 text-xs">{label}</p>
-        <div className="mb-2 flex items-center gap-2 border-b border-white/10 pb-2">
-          <p className="text-secondary text-xs">Total:</p>
-          <p className="text-xs font-medium">{totalAmount.toFixed(1)}%</p>
-        </div>
         {sortedPayload.map((entry, index) => {
           if (entry.value === 0) return null;
-          const percentage = totalAmount > 0 ? ((entry.value / totalAmount) * 100).toFixed(0) : "0";
+          const pct = grandTotal && grandTotal > 0
+            ? ((entry.value / grandTotal) * 100).toFixed(1)
+            : "0";
           return (
             <div key={index} className="flex items-center gap-2">
               <div
@@ -84,10 +83,16 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
                 style={{ backgroundColor: entry.color }}
               />
               <p className="text-secondary text-xs">{entry.name}:</p>
-              <p className="text-xs font-medium">{percentage}%</p>
+              <p className="text-xs font-medium">{pct}%</p>
             </div>
           );
         })}
+        {grandTotal && grandTotal > 0 && (
+          <div className="mt-2 flex items-center gap-2 border-t border-white/10 pt-2">
+            <p className="text-secondary text-xs">Week total:</p>
+            <p className="text-xs font-medium">{((weekTotal / grandTotal) * 100).toFixed(1)}%</p>
+          </div>
+        )}
       </div>
     );
   }
@@ -273,7 +278,7 @@ export default function ExpenditureChart({
             <YAxis hide />
             <Tooltip
               cursor={{ fill: "currentColor", fillOpacity: 0.05 }}
-              content={<CustomTooltip />}
+              content={<CustomTooltip grandTotal={totalSpent} />}
               isAnimationActive={false}
             />
             {moneyTagsArray.map((tag) => (

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -235,13 +235,33 @@ export async function fetchMoney(limit?: number): Promise<MoneyData[]> {
     limit,
   });
 
-  return rows.map((row) => ({
+  const parsed = rows.map((row) => ({
     date: (row.Date as string) || "",
     name: (row.Name as string) || "",
     cad: (row.CAD as string) || "",
     tag: (row.Tag as string) || "",
     merchant: (row.Merchant as string) || "",
   }));
+
+  // Normalize CAD values proportionally so real amounts are never exposed.
+  // The median non-zero absolute value becomes 1.0 unit; everything scales
+  // relative to it.
+  const amounts = parsed
+    .map((r) => Math.abs(parseFloat(r.cad.replace(/[^0-9.-]/g, ""))))
+    .filter((n) => !isNaN(n) && n > 0);
+
+  if (amounts.length === 0) return parsed;
+
+  const sorted = [...amounts].sort((a, b) => a - b);
+  const medianValue = sorted[Math.floor(sorted.length / 2)];
+
+  return parsed.map((row) => {
+    const raw = parseFloat(row.cad.replace(/[^0-9.-]/g, ""));
+    if (isNaN(raw) || raw === 0) return { ...row, cad: "0" };
+    const sign = raw < 0 ? -1 : 1;
+    const normalized = (Math.abs(raw) / medianValue) * sign;
+    return { ...row, cad: normalized.toFixed(2) };
+  });
 }
 
 export async function fetchScreenTime(


### PR DESCRIPTION
### Data Privacy & Normalization
- Normalized financial data from CAD to relative units (▲) to enhance privacy while maintaining proportional accuracy.
- Updated server-side data fetching and client-side rendering to support unit-based values instead of absolute currency.

### Chart & Tooltip Enhancements
- Redesigned chart tooltips to display category percentage shares for both weekly and grand totals.
- Added clear definitions for the "▲" unit and detailed explanations for bar segment meanings within the tooltip.
- Streamlined tooltip text to improve readability and focus on relative spending distribution.

### UI & Layout Refinements
- Restored the 'InfoTooltip' component and maintained consistent header layouts across the spending view.
- Removed the average spend statistic to prioritize relative percentage comparisons.

[v0 Session](https://v0.app/chat/tINFEeeknVu)