### PR TITLE
Aggregate analytics data before hydration

### DIFF
--- a/app/(main)/analytics/page.tsx
+++ b/app/(main)/analytics/page.tsx
@@ -8,6 +8,13 @@ import {
   fetchMoney,
 } from "@/lib/sheets";
 import { fetchGitHubContributions } from "@/lib/github";
+import {
+  aggregateMoneyData,
+  aggregateRatings,
+  aggregateScreenTimeData,
+  aggregateSleepData,
+  aggregateWorkoutData,
+} from "@/lib/analytics-data";
 
 export default async function AnalyticsPage() {
   "use cache";
@@ -16,9 +23,9 @@ export default async function AnalyticsPage() {
   const [
     workData,
     sheetsData,
-    screenTimeData,
-    workoutData,
-    moneyData,
+    rawScreenTimeData,
+    rawWorkoutData,
+    rawMoneyData,
     githubData,
   ] = await Promise.all([
     getWorkData(2000),
@@ -33,12 +40,18 @@ export default async function AnalyticsPage() {
   today.setHours(0, 0, 0, 0);
   const todayTimestamp = today.getTime();
 
+  const ratingData = aggregateRatings(sheetsData.overview);
+  const sleepData = aggregateSleepData(sheetsData.sleep, sheetsData.overview);
+  const screenTimeData = aggregateScreenTimeData(rawScreenTimeData);
+  const workoutData = aggregateWorkoutData(rawWorkoutData, todayTimestamp);
+  const moneyData = aggregateMoneyData(rawMoneyData, todayTimestamp);
+
   return (
     <AnalyticsClient
       workData={workData}
-      sleepData={sheetsData.sleep}
+      ratingData={ratingData}
+      sleepData={sleepData}
       screenTimeData={screenTimeData}
-      overviewData={sheetsData.overview}
       workoutData={workoutData}
       moneyData={moneyData}
       githubData={githubData}

--- a/components/Analytics/Analytics.tsx
+++ b/components/Analytics/Analytics.tsx
@@ -95,7 +95,6 @@ export default function Analytics({
   }
 
   const presets: TimePreset[] = [
-    { label: "14d", days: 14 },
     { label: "1m", days: 30 },
     { label: "3m", days: 90 },
     { label: "6m", days: 180 },

--- a/components/Analytics/Analytics.tsx
+++ b/components/Analytics/Analytics.tsx
@@ -4,14 +4,13 @@ import { useState } from "react";
 import ProjectsChart from "@/components/Analytics/ProjectsChart";
 import ProjectsPieChart from "@/components/Analytics/ProjectsPieChart";
 import type { ProcessedWorkData } from "@/lib/work";
-import type {
-  SleepData,
-  ScreenTimeData,
-  OverviewData,
-  WorkoutData,
-  MoneyData,
-} from "@/lib/sheets";
 import type { ContributionsData } from "@/lib/github";
+import type {
+  DailyRatingData,
+  DailyScreenTimeAggregate,
+  DailySleepAggregate,
+  WeeklySeriesData,
+} from "@/lib/analytics-data";
 import SleepTrendsChart from "@/components/Analytics/SleepTrendsChart";
 import ScreenTimePieChart from "@/components/Analytics/ScreenTimePieChart";
 import WorkoutsChart from "@/components/Analytics/WorkoutsChart";
@@ -25,43 +24,26 @@ type TimePreset = {
 
 type AnalyticsProps = {
   workData: ProcessedWorkData;
-  sleepData: SleepData[];
-  screenTimeData: ScreenTimeData[];
-  overviewData: OverviewData[];
-  workoutData: WorkoutData[];
-  moneyData: MoneyData[];
+  ratingData: DailyRatingData[];
+  sleepData: DailySleepAggregate[];
+  screenTimeData: DailyScreenTimeAggregate[];
+  workoutData: WeeklySeriesData[];
+  moneyData: WeeklySeriesData[];
   githubData: ContributionsData;
   todayTimestamp: number;
 };
 
-function parseTimeToMinutes(timeStr: string): number {
-  if (!timeStr || timeStr.trim() === "") return 0;
-
-  const hourMatch = timeStr.match(/(\d+)h/);
-  const minuteMatch = timeStr.match(/(\d+)m/);
-
-  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
-  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
-
-  return hours * 60 + minutes;
-}
-
 export default function Analytics({
   workData,
+  ratingData,
   sleepData,
   screenTimeData,
-  overviewData,
   workoutData,
   moneyData,
   githubData,
   todayTimestamp,
 }: AnalyticsProps) {
   const filteredWorkDataAll = workData.dailyData;
-  const filteredSleepDataAll = sleepData;
-  const filteredScreenTimeDataAll = screenTimeData;
-  const filteredOverviewDataAll = overviewData;
-  const filteredWorkoutDataAll = workoutData;
-  const filteredMoneyDataAll = moneyData;
 
   const hasData = filteredWorkDataAll.length > 0;
   const defaultDays = hasData ? Math.min(90, filteredWorkDataAll.length) : 0;
@@ -80,14 +62,6 @@ export default function Analytics({
 
   const filteredWorkData = workDataToUse.slice(0, days);
 
-  const filteredProjectTotals: Record<string, number> = {};
-  filteredWorkData.forEach((d) => {
-    Object.entries(d.projects).forEach(([project, minutes]) => {
-      filteredProjectTotals[project] =
-        (filteredProjectTotals[project] || 0) + minutes;
-    });
-  });
-
   const pieProjectTotals: Record<string, number> = {};
   const pieWorkData = isAllTime ? filteredWorkDataAll : filteredWorkData;
   pieWorkData.forEach((d) => {
@@ -96,25 +70,21 @@ export default function Analytics({
     });
   });
 
-  const filteredSleepData = filteredSleepDataAll.slice(0, days);
-  const sleepMinutes = filteredSleepData.reduce((sum, entry) => {
-    return sum + parseTimeToMinutes(entry.time);
-  }, 0);
+  const sleepMinutes = sleepData
+    .slice(0, days)
+    .reduce((sum, entry) => sum + entry.total, 0);
 
   const screenDateSet = new Set<string>();
-  const filteredScreenData: ScreenTimeData[] = [];
-  for (const entry of filteredScreenTimeDataAll) {
+  let screenMinutes = 0;
+  for (const entry of screenTimeData) {
     if (!screenDateSet.has(entry.date)) {
       if (screenDateSet.size >= days) break;
       screenDateSet.add(entry.date);
     }
     if (screenDateSet.has(entry.date)) {
-      filteredScreenData.push(entry);
+      screenMinutes += entry.minutes;
     }
   }
-  const screenMinutes = filteredScreenData.reduce((sum, entry) => {
-    return sum + parseTimeToMinutes(entry.duration);
-  }, 0);
 
   if (!hasData) {
     return (
@@ -175,7 +145,7 @@ export default function Analytics({
         <div className="border-border flex flex-col border-b md:col-span-3 md:border-b-0">
           <ProjectsChart
             data={filteredWorkDataAll}
-            overviewData={filteredOverviewDataAll}
+            ratingData={ratingData}
             days={days}
             todayTimestamp={todayTimestamp}
           />
@@ -192,14 +162,14 @@ export default function Analytics({
       <div className="divide-border grid w-full grid-cols-1 md:grid-cols-4 md:divide-x">
         <div className="border-border border-b md:col-span-2">
           <WorkoutsChart
-            data={filteredWorkoutDataAll}
+            data={workoutData}
             days={days}
             todayTimestamp={todayTimestamp}
           />
         </div>
         <div className="border-border border-b md:col-span-2">
           <ExpenditureChart
-            data={filteredMoneyDataAll}
+            data={moneyData}
             days={days}
             todayTimestamp={todayTimestamp}
           />
@@ -215,14 +185,13 @@ export default function Analytics({
       <div className="divide-border grid w-full grid-cols-1 md:grid-cols-4 md:divide-x">
         <div className="border-border border-b md:col-span-3">
           <SleepTrendsChart
-            data={filteredSleepDataAll}
-            overviewData={filteredOverviewDataAll}
+            data={sleepData}
             days={days}
             todayTimestamp={todayTimestamp}
           />
         </div>
         <div className="border-border border-b">
-          <ScreenTimePieChart data={filteredScreenTimeDataAll} days={days} />
+          <ScreenTimePieChart data={screenTimeData} days={days} />
         </div>
       </div>
     </div>

--- a/components/Analytics/ContributionsChart.tsx
+++ b/components/Analytics/ContributionsChart.tsx
@@ -38,7 +38,6 @@ export default function ContributionsChart({ data }: ContributionsChartProps) {
 
   const {
     totalContributions,
-    avgPerDay,
     currentStreak,
     longestStreak,
     totalDays,
@@ -46,7 +45,6 @@ export default function ContributionsChart({ data }: ContributionsChartProps) {
     if (!data.weeks || data.weeks.length === 0) {
       return {
         totalContributions: 0,
-        avgPerDay: 0,
         currentStreak: 0,
         longestStreak: 0,
         totalDays: 0,
@@ -56,8 +54,6 @@ export default function ContributionsChart({ data }: ContributionsChartProps) {
     const allDays = data.weeks.flatMap((week) => week.contributionDays);
 
     const total = allDays.reduce((sum, day) => sum + day.contributionCount, 0);
-    const avg = allDays.length > 0 ? total / allDays.length : 0;
-
     const allDaysSorted = [...allDays].sort(
       (a, b) =>
         parseDateString(b.date).getTime() - parseDateString(a.date).getTime(),
@@ -91,7 +87,6 @@ export default function ContributionsChart({ data }: ContributionsChartProps) {
 
     return {
       totalContributions: total,
-      avgPerDay: avg,
       currentStreak: current,
       longestStreak: longest,
       totalDays: allDays.length,

--- a/components/Analytics/ExpenditureChart.tsx
+++ b/components/Analytics/ExpenditureChart.tsx
@@ -8,12 +8,12 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import type { MoneyData } from "@/lib/sheets";
+import type { WeeklySeriesData } from "@/lib/analytics-data";
 import { SPENDING_COLORS } from "@/lib/colors";
 import InfoTooltip from "@/components/Home/InfoTooltip";
 
 type ExpenditureChartProps = {
-  data: MoneyData[];
+  data: WeeklySeriesData[];
   days?: number;
   todayTimestamp: number;
 };
@@ -30,41 +30,12 @@ type CustomTooltipProps = {
   grandTotal?: number;
 };
 
-type WeekData = {
-  week: string;
-  weekLabel: string;
-  [key: string]: number | string;
-};
-
-function getWeekLabel(weekKey: string): string {
-  const parts = weekKey.split("-");
-  const year = parseInt(parts[0], 10);
-  const month = parseInt(parts[1], 10) - 1;
-  const day = parseInt(parts[2], 10);
-
-  const startOfWeek = new Date(year, month, day);
-  const endOfWeek = new Date(year, month, day + 6);
-
-  const formatDate = (d: Date) => {
-    const month = d.toLocaleString("en-US", { month: "short" });
-    const day = d.getDate();
-    const year = d.getFullYear();
-    return `${month} ${day}, ${year}`;
-  };
-
-  return `${formatDate(startOfWeek)} - ${formatDate(endOfWeek)}`;
-}
-
-function getWeekKey(date: Date): string {
-  const startOfWeek = new Date(date);
-  const day = startOfWeek.getDay();
-  const diff = startOfWeek.getDate() - day + (day === 0 ? -6 : 1);
-  startOfWeek.setDate(diff);
-  startOfWeek.setHours(0, 0, 0, 0);
-  return startOfWeek.toISOString().split("T")[0];
-}
-
-function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProps) {
+function CustomTooltip({
+  active,
+  payload,
+  label,
+  grandTotal,
+}: CustomTooltipProps) {
   if (active && payload && payload.length) {
     const sortedPayload = [...payload].sort((a, b) => b.value - a.value);
     const weekTotal = payload.reduce((sum, entry) => sum + entry.value, 0);
@@ -74,9 +45,10 @@ function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProp
         <p className="text-secondary mb-2 text-xs">{label}</p>
         {sortedPayload.map((entry, index) => {
           if (entry.value === 0) return null;
-          const pct = grandTotal && grandTotal > 0
-            ? ((entry.value / grandTotal) * 100).toFixed(1)
-            : "0";
+          const pct =
+            grandTotal && grandTotal > 0
+              ? ((entry.value / grandTotal) * 100).toFixed(1)
+              : "0";
           return (
             <div key={index} className="flex items-center gap-2">
               <div
@@ -91,7 +63,9 @@ function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProp
         {grandTotal && grandTotal > 0 && (
           <div className="mt-2 flex items-center gap-2 border-t border-white/10 pt-2">
             <p className="text-secondary text-xs">Week total:</p>
-            <p className="text-xs font-medium">{((weekTotal / grandTotal) * 100).toFixed(1)}▲</p>
+            <p className="text-xs font-medium">
+              {((weekTotal / grandTotal) * 100).toFixed(1)}▲
+            </p>
           </div>
         )}
       </div>
@@ -100,156 +74,39 @@ function CustomTooltip({ active, payload, label, grandTotal }: CustomTooltipProp
   return null;
 }
 
+function getStartDate(todayTimestamp: number, days: number): Date {
+  const today = new Date(todayTimestamp);
+  today.setHours(0, 0, 0, 0);
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - days + 1);
+  startDate.setHours(0, 0, 0, 0);
+  return startDate;
+}
+
 export default function ExpenditureChart({
   data,
   days = 90,
   todayTimestamp,
 }: ExpenditureChartProps) {
-  const today = new Date(todayTimestamp);
-  today.setHours(0, 0, 0, 0);
-  const endDate = new Date(today);
-
-  const parseMoneyDate = (dateStr: string): Date | null => {
-    try {
-      const parts = dateStr.split(",").map((p) => p.trim());
-      if (parts.length < 2) return null;
-
-      const dateComponents = parts[1].split(" ");
-      if (dateComponents.length < 2) return null;
-
-      const month = dateComponents[0];
-      const day = parseInt(dateComponents[1], 10);
-      const year = parts.length >= 3 ? parseInt(parts[2], 10) : null;
-
-      const monthMap: Record<string, number> = {
-        Jan: 0,
-        Feb: 1,
-        Mar: 2,
-        Apr: 3,
-        May: 4,
-        Jun: 5,
-        Jul: 6,
-        Aug: 7,
-        Sep: 8,
-        Oct: 9,
-        Nov: 10,
-        Dec: 11,
-      };
-
-      const monthNum = monthMap[month];
-      if (monthNum === undefined) return null;
-
-      let finalYear: number;
-      if (year) {
-        finalYear = year;
-      } else {
-        const currentYear = today.getFullYear();
-        const testDate = new Date(currentYear, monthNum, day);
-        finalYear = testDate > today ? currentYear - 1 : currentYear;
-      }
-
-      const moneyDate = new Date(finalYear, monthNum, day);
-      moneyDate.setHours(0, 0, 0, 0);
-      return moneyDate;
-    } catch {
-      return null;
-    }
-  };
-
-  // Hard cutoff - don't show data before this date
+  const startDate = getStartDate(todayTimestamp, days);
   const cutoffDate = new Date("2022-09-01");
   cutoffDate.setHours(0, 0, 0, 0);
+  const effectiveStart = startDate < cutoffDate ? cutoffDate : startDate;
 
-  // Find earliest transaction date after the cutoff
-  const validDates: Date[] = [];
-  data.forEach((transaction) => {
-    if (transaction.date && transaction.cad) {
-      const parsed = parseMoneyDate(transaction.date);
-      if (parsed && !isNaN(parsed.getTime()) && parsed >= cutoffDate) {
-        validDates.push(parsed);
-      }
-    }
-  });
-  const earliestDataDate =
-    validDates.length > 0
-      ? new Date(Math.min(...validDates.map((d) => d.getTime())))
-      : null;
+  const chartData = data.filter((week) => new Date(week.week) >= effectiveStart);
 
-  const requestedStart = new Date(endDate);
-  requestedStart.setDate(endDate.getDate() - days + 1);
-  requestedStart.setHours(0, 0, 0, 0);
-
-  // Ensure we don't go before cutoff date
-  const effectiveRequestedStart =
-    requestedStart < cutoffDate ? cutoffDate : requestedStart;
-
-  // Start from the earliest transaction date (after cutoff) or the requested start
-  let startDate = effectiveRequestedStart;
-  if (earliestDataDate && earliestDataDate > effectiveRequestedStart) {
-    startDate = earliestDataDate;
-  }
-
-  const allWeekKeys = new Set<string>();
-  const currentDate = new Date(startDate);
-  while (currentDate <= endDate) {
-    allWeekKeys.add(getWeekKey(currentDate));
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
-
-  const weekMap = new Map<string, Map<string, number>>();
   const moneyTags = new Set<string>();
-
-  allWeekKeys.forEach((weekKey) => {
-    weekMap.set(weekKey, new Map());
-  });
-
-  data.forEach((transaction) => {
-    if (!transaction.date || !transaction.cad) return;
-
-    const moneyDate = parseMoneyDate(transaction.date);
-
-    if (!moneyDate || isNaN(moneyDate.getTime())) return;
-
-    if (moneyDate >= startDate && moneyDate <= endDate) {
-      const weekKey = getWeekKey(moneyDate);
-      const tag = transaction.tag || "Other";
-      const amount = parseFloat(transaction.cad.replace(/[^0-9.-]/g, ""));
-
-      if (isNaN(amount) || amount === 0) return;
-      if (tag === "Investments") return;
-
-      moneyTags.add(tag);
-
-      if (!weekMap.has(weekKey)) {
-        weekMap.set(weekKey, new Map());
+  chartData.forEach((week) => {
+    Object.entries(week).forEach(([key, value]) => {
+      if (key !== "week" && key !== "weekLabel" && typeof value === "number") {
+        moneyTags.add(key);
       }
-
-      const tagMap = weekMap.get(weekKey)!;
-      tagMap.set(tag, (tagMap.get(tag) || 0) + Math.abs(amount));
-    }
+    });
   });
 
   if (moneyTags.size === 0) {
     moneyTags.add("No Data");
   }
-
-  const weeks = Array.from(weekMap.entries())
-    .map(([weekKey, tagMap]) => {
-      const weekLabel = getWeekLabel(weekKey);
-      const weekData: WeekData = {
-        week: weekKey,
-        weekLabel,
-      };
-
-      tagMap.forEach((amount, tag) => {
-        weekData[tag] = amount;
-      });
-
-      return weekData;
-    })
-    .sort((a, b) => new Date(a.week).getTime() - new Date(b.week).getTime());
-
-  const chartData = weeks;
 
   const totalSpent = chartData.reduce((sum, week) => {
     return (

--- a/components/Analytics/ProjectsChart.tsx
+++ b/components/Analytics/ProjectsChart.tsx
@@ -9,12 +9,12 @@ import {
   Tooltip,
 } from "recharts";
 import type { DailyWorkData } from "@/lib/work";
-import type { OverviewData } from "@/lib/sheets";
+import type { DailyRatingData } from "@/lib/analytics-data";
 import { PROJECT_COLORS, CHART_COLORS } from "@/lib/colors";
 
 type ProjectsChartProps = {
   data: DailyWorkData[];
-  overviewData: OverviewData[];
+  ratingData: DailyRatingData[];
   days?: number;
   todayTimestamp: number;
 };
@@ -155,7 +155,7 @@ function formatDateKey(date: Date): string {
 
 export default function ProjectsChart({
   data,
-  overviewData,
+  ratingData,
   days = 7,
   todayTimestamp,
 }: ProjectsChartProps) {
@@ -183,11 +183,8 @@ export default function ProjectsChart({
   allDates.reverse();
 
   const ratingMap = new Map<string, number>();
-  overviewData.forEach((d) => {
-    const rating = parseFloat(d.r);
-    if (!isNaN(rating)) {
-      ratingMap.set(d.date, rating);
-    }
+  ratingData.forEach((d) => {
+    ratingMap.set(d.date, d.rating);
   });
 
   const projectTotals = new Map<string, number>();

--- a/components/Analytics/ScreenTimePieChart.tsx
+++ b/components/Analytics/ScreenTimePieChart.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
-import type { ScreenTimeData } from "@/lib/sheets";
+import type { DailyScreenTimeAggregate } from "@/lib/analytics-data";
 import { CHART_COLORS } from "@/lib/colors";
 
 type ScreenTimePieChartProps = {
-  data: ScreenTimeData[];
+  data: DailyScreenTimeAggregate[];
   days?: number;
 };
 
@@ -23,18 +23,6 @@ type CustomTooltipProps = {
   active?: boolean;
   payload?: TooltipPayload[];
 };
-
-function parseTimeToMinutes(timeStr: string): number {
-  if (!timeStr || timeStr.trim() === "") return 0;
-
-  const hourMatch = timeStr.match(/(\d+)h/);
-  const minuteMatch = timeStr.match(/(\d+)m/);
-
-  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
-  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
-
-  return hours * 60 + minutes;
-}
 
 function CustomTooltip({ active, payload }: CustomTooltipProps) {
   if (active && payload && payload.length) {
@@ -66,7 +54,7 @@ export default function ScreenTimePieChart({
   days = 14,
 }: ScreenTimePieChartProps) {
   const dateSet = new Set<string>();
-  const filteredData: ScreenTimeData[] = [];
+  const filteredData: DailyScreenTimeAggregate[] = [];
 
   for (const entry of data) {
     if (!dateSet.has(entry.date)) {
@@ -80,9 +68,10 @@ export default function ScreenTimePieChart({
 
   const categoryTotals = new Map<string, number>();
   filteredData.forEach((entry) => {
-    const category = entry.category || "Other";
-    const minutes = parseTimeToMinutes(entry.duration);
-    categoryTotals.set(category, (categoryTotals.get(category) || 0) + minutes);
+    categoryTotals.set(
+      entry.category,
+      (categoryTotals.get(entry.category) || 0) + entry.minutes,
+    );
   });
 
   const totalMinutes = Array.from(categoryTotals.values()).reduce(
@@ -129,7 +118,6 @@ export default function ScreenTimePieChart({
     { filteredCategories: [], otherTotal: 0 },
   );
 
-  // Add small categories to existing "Other" or create new one
   if (otherTotal > 0) {
     const existingOtherIndex = filteredCategories.findIndex(
       (c) => c.name === "Other",

--- a/components/Analytics/SleepTrendsChart.tsx
+++ b/components/Analytics/SleepTrendsChart.tsx
@@ -8,12 +8,11 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import type { SleepData, OverviewData } from "@/lib/sheets";
+import type { DailySleepAggregate } from "@/lib/analytics-data";
 import { SLEEP_COLORS } from "@/lib/colors";
 
 type SleepTrendsChartProps = {
-  data: SleepData[];
-  overviewData: OverviewData[];
+  data: DailySleepAggregate[];
   days?: number;
   todayTimestamp: number;
 };
@@ -32,18 +31,6 @@ type CustomTooltipProps = {
     };
   }>;
 };
-
-function parseTimeToMinutes(timeStr: string): number {
-  if (!timeStr || timeStr.trim() === "") return 0;
-
-  const hourMatch = timeStr.match(/(\d+)h/);
-  const minuteMatch = timeStr.match(/(\d+)m/);
-
-  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
-  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
-
-  return hours * 60 + minutes;
-}
 
 function getRatingLabel(rating: number): string {
   const roundedRating = Math.round(rating);
@@ -112,111 +99,29 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
   return null;
 }
 
-function formatDateKey(date: Date): string {
-  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
-  const dayOfWeek = days[date.getDay()];
-  const month = months[date.getMonth()];
-  const day = date.getDate();
-  const year = date.getFullYear();
-  return `${dayOfWeek}, ${month} ${day}, ${year}`;
+function getStartDate(todayTimestamp: number, days: number): Date {
+  const today = new Date(todayTimestamp);
+  today.setHours(0, 0, 0, 0);
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - days + 1);
+  startDate.setHours(0, 0, 0, 0);
+  return startDate;
 }
 
 export default function SleepTrendsChart({
   data,
-  overviewData,
   days = 14,
   todayTimestamp,
 }: SleepTrendsChartProps) {
-  const today = new Date(todayTimestamp);
-  today.setHours(0, 0, 0, 0);
-  const endDate = new Date(today);
-
-  const validDates: Date[] = [];
-  data.forEach((d) => {
-    if (d.date && d.time) {
-      const parsed = new Date(d.date);
-      if (!isNaN(parsed.getTime())) {
-        validDates.push(parsed);
-      }
-    }
-  });
-  const earliestDataDate =
-    validDates.length > 0
-      ? new Date(Math.min(...validDates.map((d) => d.getTime())))
-      : null;
-
-  const sleepDataMap = new Map<string, SleepData>();
-  data.forEach((d) => {
-    sleepDataMap.set(d.date, d);
-  });
-
-  const requestedStart = new Date(endDate);
-  requestedStart.setDate(endDate.getDate() - days + 1);
-  requestedStart.setHours(0, 0, 0, 0);
-
-  let startDate = requestedStart;
-  if (earliestDataDate && earliestDataDate > requestedStart) {
-    startDate = earliestDataDate;
-  }
-
-  const allDates: Date[] = [];
-  const currentDate = new Date(startDate);
-  currentDate.setHours(0, 0, 0, 0);
-  while (currentDate <= endDate) {
-    allDates.push(new Date(currentDate));
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
-
-  const ratingMap = new Map<string, number>();
-  overviewData.forEach((d) => {
-    const rating = parseFloat(d.r);
-    if (!isNaN(rating)) {
-      ratingMap.set(d.date, rating);
-    }
-  });
-
-  const chartData = allDates.map((date, index) => {
-    const dateKey = formatDateKey(date);
-    const dayData = sleepDataMap.get(dateKey);
-
-    const totalMinutes = dayData ? parseTimeToMinutes(dayData.time) : 0;
-    const remMinutes = dayData ? parseTimeToMinutes(dayData.rem) : 0;
-    const deepMinutes = dayData ? parseTimeToMinutes(dayData.deep) : 0;
-    const lightMinutes = Math.max(0, totalMinutes - remMinutes - deepMinutes);
-
-    const rating = ratingMap.get(dateKey) || 0;
-    const scaledRating = rating > 0 ? (rating / 7) * 600 : 0;
-
-    return {
-      index,
-      date: dateKey,
-      score: dayData?.score || "",
-      total: totalMinutes,
-      rem: remMinutes,
-      deep: deepMinutes,
-      light: lightMinutes,
-      rating: scaledRating,
-      rawRating: rating,
-    };
-  });
+  const startDate = getStartDate(todayTimestamp, days);
+  const chartData = data
+    .filter((entry) => new Date(entry.date) >= startDate)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    .map((entry, index) => ({ ...entry, index }));
 
   const totalSleepMinutes = chartData.reduce((sum, d) => sum + d.total, 0);
   const avgTotal =
-    allDates.length > 0 ? totalSleepMinutes / allDates.length : 0;
+    chartData.length > 0 ? totalSleepMinutes / chartData.length : 0;
 
   const avgHours = Math.floor(avgTotal / 60);
   const avgMins = Math.round(avgTotal % 60);

--- a/components/Analytics/WorkoutsChart.tsx
+++ b/components/Analytics/WorkoutsChart.tsx
@@ -8,11 +8,11 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
-import type { WorkoutData } from "@/lib/sheets";
+import type { WeeklySeriesData } from "@/lib/analytics-data";
 import { WORKOUT_COLORS } from "@/lib/colors";
 
 type WorkoutsChartProps = {
-  data: WorkoutData[];
+  data: WeeklySeriesData[];
   days?: number;
   todayTimestamp: number;
 };
@@ -27,55 +27,6 @@ type CustomTooltipProps = {
   }>;
   label?: string;
 };
-
-type WeekData = {
-  week: string;
-  weekLabel: string;
-  [key: string]: number | string;
-};
-
-function parseTimeToMinutes(timeStr: string): number {
-  if (!timeStr || timeStr.trim() === "") return 0;
-
-  const hourMatch = timeStr.match(/(\d+)h/);
-  const minuteMatch = timeStr.match(/(\d+)m/);
-  const secondMatch = timeStr.match(/(\d+)s/);
-
-  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
-  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
-  const seconds = secondMatch ? parseInt(secondMatch[1], 10) : 0;
-
-  return hours * 60 + minutes + Math.round(seconds / 60);
-}
-
-function getWeekLabel(date: Date): string {
-  const startOfWeek = new Date(date);
-  const day = startOfWeek.getDay();
-  const diff = startOfWeek.getDate() - day + (day === 0 ? -6 : 1);
-  startOfWeek.setDate(diff);
-  startOfWeek.setHours(0, 0, 0, 0);
-
-  const endOfWeek = new Date(startOfWeek);
-  endOfWeek.setDate(startOfWeek.getDate() + 6);
-
-  const formatDate = (d: Date) => {
-    const month = d.toLocaleString("en-US", { month: "short" });
-    const day = d.getDate();
-    const year = d.getFullYear();
-    return `${month} ${day}, ${year}`;
-  };
-
-  return `${formatDate(startOfWeek)} - ${formatDate(endOfWeek)}`;
-}
-
-function getWeekKey(date: Date): string {
-  const startOfWeek = new Date(date);
-  const day = startOfWeek.getDay();
-  const diff = startOfWeek.getDate() - day + (day === 0 ? -6 : 1);
-  startOfWeek.setDate(diff);
-  startOfWeek.setHours(0, 0, 0, 0);
-  return startOfWeek.toISOString().split("T")[0];
-}
 
 function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
   if (active && payload && payload.length) {
@@ -116,142 +67,35 @@ function CustomTooltip({ active, payload, label }: CustomTooltipProps) {
   return null;
 }
 
+function getStartDate(todayTimestamp: number, days: number): Date {
+  const today = new Date(todayTimestamp);
+  today.setHours(0, 0, 0, 0);
+  const startDate = new Date(today);
+  startDate.setDate(today.getDate() - days + 1);
+  startDate.setHours(0, 0, 0, 0);
+  return startDate;
+}
+
 export default function WorkoutsChart({
   data,
   days = 90,
   todayTimestamp,
 }: WorkoutsChartProps) {
-  const today = new Date(todayTimestamp);
-  today.setHours(0, 0, 0, 0);
-  const endDate = new Date(today);
+  const startDate = getStartDate(todayTimestamp, days);
+  const chartData = data.filter((week) => new Date(week.week) >= startDate);
 
-  const parseWorkoutDate = (dateStr: string): Date | null => {
-    try {
-      const parts = dateStr.split(",");
-      if (parts.length < 2) return null;
-
-      const monthDay = parts[1].trim().split(" ");
-      if (monthDay.length < 2) return null;
-
-      const month = monthDay[0];
-      const day = parseInt(monthDay[1], 10);
-
-      const monthMap: Record<string, number> = {
-        Jan: 0,
-        Feb: 1,
-        Mar: 2,
-        Apr: 3,
-        May: 4,
-        Jun: 5,
-        Jul: 6,
-        Aug: 7,
-        Sep: 8,
-        Oct: 9,
-        Nov: 10,
-        Dec: 11,
-      };
-
-      const monthNum = monthMap[month];
-      if (monthNum === undefined) return null;
-
-      const currentYear = today.getFullYear();
-      let workoutDate = new Date(currentYear, monthNum, day);
-
-      if (workoutDate > today) {
-        workoutDate = new Date(currentYear - 1, monthNum, day);
-      }
-
-      workoutDate.setHours(0, 0, 0, 0);
-      return workoutDate;
-    } catch {
-      return null;
-    }
-  };
-
-  const validDates: Date[] = [];
-  data.forEach((workout) => {
-    if (workout.date && workout.time) {
-      const parsed = parseWorkoutDate(workout.date);
-      if (parsed && !isNaN(parsed.getTime())) {
-        validDates.push(parsed);
-      }
-    }
-  });
-  const earliestDataDate =
-    validDates.length > 0
-      ? new Date(Math.min(...validDates.map((d) => d.getTime())))
-      : null;
-
-  const requestedStart = new Date(endDate);
-  requestedStart.setDate(endDate.getDate() - days + 1);
-  requestedStart.setHours(0, 0, 0, 0);
-
-  let startDate = requestedStart;
-  if (earliestDataDate && earliestDataDate > requestedStart) {
-    startDate = earliestDataDate;
-  }
-
-  const allWeekKeys = new Set<string>();
-  const currentDate = new Date(startDate);
-  while (currentDate <= endDate) {
-    allWeekKeys.add(getWeekKey(currentDate));
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
-
-  const weekMap = new Map<string, Map<string, number>>();
   const workoutTypes = new Set<string>();
-
-  allWeekKeys.forEach((weekKey) => {
-    weekMap.set(weekKey, new Map());
-  });
-
-  data.forEach((workout) => {
-    if (!workout.date || !workout.time) return;
-
-    const workoutDate = parseWorkoutDate(workout.date);
-
-    if (!workoutDate || isNaN(workoutDate.getTime())) return;
-
-    if (workoutDate >= startDate && workoutDate <= endDate) {
-      const weekKey = getWeekKey(workoutDate);
-      const workoutType = workout.type || "Other";
-      const minutes = parseTimeToMinutes(workout.time);
-
-      if (minutes === 0) return;
-
-      workoutTypes.add(workoutType);
-
-      if (!weekMap.has(weekKey)) {
-        weekMap.set(weekKey, new Map());
+  chartData.forEach((week) => {
+    Object.entries(week).forEach(([key, value]) => {
+      if (key !== "week" && key !== "weekLabel" && typeof value === "number") {
+        workoutTypes.add(key);
       }
-
-      const typeMap = weekMap.get(weekKey)!;
-      typeMap.set(workoutType, (typeMap.get(workoutType) || 0) + minutes);
-    }
+    });
   });
 
   if (workoutTypes.size === 0) {
     workoutTypes.add("No Data");
   }
-
-  const weeks = Array.from(weekMap.entries())
-    .map(([weekKey, typeMap]) => {
-      const weekDate = new Date(weekKey);
-      const weekLabel = getWeekLabel(weekDate);
-      const weekData: WeekData = {
-        week: weekKey,
-        weekLabel,
-      };
-
-      typeMap.forEach((minutes, type) => {
-        weekData[type] = minutes;
-      });
-
-      return weekData;
-    })
-    .sort((a, b) => new Date(a.week).getTime() - new Date(b.week).getTime());
-
-  const chartData = weeks;
 
   const totalMinutes = chartData.reduce((sum, week) => {
     return (

--- a/components/Home/Geometry.tsx
+++ b/components/Home/Geometry.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type ShapeId = "circle" | "diamond" | "triangle";
 
@@ -79,7 +79,6 @@ const renderShape = (shape: ShapeId) => {
 export default function Geometry() {
   const [shape, setShape] = useState<ShapeId>("diamond");
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const meshPatternId = `mesh-${useId()}`;
 
   const stopCycling = () => {
     if (timerRef.current) {

--- a/components/Projects/ProjectsGrid.tsx
+++ b/components/Projects/ProjectsGrid.tsx
@@ -6,10 +6,6 @@ import ProjectCard from "@/components/Common/ProjectCard";
 
 const TAGS: ProjectTag[] = ["Engineering", "Research", "Community"];
 
-function getYear(date: string): string {
-  return date.match(/\d{4}/)?.[0] || "0";
-}
-
 export default function ProjectsGrid({ projects }: { projects: Project[] }) {
   const [activeTags, setActiveTags] = useState<Set<ProjectTag>>(new Set());
 
@@ -26,15 +22,6 @@ export default function ProjectsGrid({ projects }: { projects: Project[] }) {
     activeTags.size > 0
       ? projects.filter((p) => p.tags.some((t) => activeTags.has(t)))
       : projects;
-
-  const grouped = filtered.reduce<Record<string, Project[]>>((acc, project) => {
-    const year = getYear(project.date);
-    if (!acc[year]) acc[year] = [];
-    acc[year].push(project);
-    return acc;
-  }, {});
-
-  const years = Object.keys(grouped).sort((a, b) => parseInt(b) - parseInt(a));
 
   return (
     <div className="flex w-full flex-col items-start justify-start p-6 md:p-16">

--- a/components/Work/TableOfContents.tsx
+++ b/components/Work/TableOfContents.tsx
@@ -53,23 +53,23 @@ export default function TableOfContents() {
   }, [updateActiveHeading]);
 
   useEffect(() => {
-    collectHeadings();
-    updateActiveHeading();
+    const refresh = () => {
+      requestAnimationFrame(() => {
+        collectHeadings();
+        updateActiveHeading();
+      });
+    };
 
-    const observer = new MutationObserver(() => {
-      collectHeadings();
-      updateActiveHeading();
-    });
+    refresh();
+
+    const observer = new MutationObserver(refresh);
 
     const article = document.querySelector(".prose-content");
     if (article) {
       observer.observe(article, { childList: true, subtree: true });
     }
 
-    const timer = setTimeout(() => {
-      collectHeadings();
-      updateActiveHeading();
-    }, 500);
+    const timer = setTimeout(refresh, 500);
 
     window.addEventListener("scroll", onScroll, { passive: true });
 

--- a/lib/analytics-data.ts
+++ b/lib/analytics-data.ts
@@ -1,0 +1,303 @@
+import type { OverviewData, SleepData, ScreenTimeData, WorkoutData, MoneyData } from "@/lib/sheets";
+
+export type DailyRatingData = {
+  date: string;
+  rating: number;
+};
+
+export type DailySleepAggregate = {
+  index: number;
+  date: string;
+  total: number;
+  rem: number;
+  deep: number;
+  light: number;
+  score: string;
+  rawRating: number;
+};
+
+export type DailyScreenTimeAggregate = {
+  date: string;
+  category: string;
+  minutes: number;
+};
+
+export type WeeklySeriesData = {
+  week: string;
+  weekLabel: string;
+  [key: string]: number | string;
+};
+
+const MONTHS: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+};
+
+function parseTimeToMinutes(timeStr: string): number {
+  if (!timeStr || timeStr.trim() === "") return 0;
+
+  const hourMatch = timeStr.match(/(\d+)h/);
+  const minuteMatch = timeStr.match(/(\d+)m/);
+  const secondMatch = timeStr.match(/(\d+)s/);
+
+  const hours = hourMatch ? parseInt(hourMatch[1], 10) : 0;
+  const minutes = minuteMatch ? parseInt(minuteMatch[1], 10) : 0;
+  const seconds = secondMatch ? parseInt(secondMatch[1], 10) : 0;
+
+  return hours * 60 + minutes + Math.round(seconds / 60);
+}
+
+function formatMinutes(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  return `${hours}h ${mins}m`;
+}
+
+function formatDateKey(date: Date): string {
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  return `${days[date.getDay()]}, ${months[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+}
+
+function parseSheetDate(dateStr: string, today: Date): Date | null {
+  try {
+    const parts = dateStr.split(",").map((part) => part.trim());
+    if (parts.length < 2) return null;
+
+    const monthDay = parts[1].split(" ");
+    if (monthDay.length < 2) return null;
+
+    const month = MONTHS[monthDay[0]];
+    const day = parseInt(monthDay[1], 10);
+    if (month === undefined || Number.isNaN(day)) return null;
+
+    const explicitYear = parts.length >= 3 ? parseInt(parts[2], 10) : NaN;
+    let year = Number.isNaN(explicitYear) ? today.getFullYear() : explicitYear;
+
+    let parsed = new Date(year, month, day);
+    parsed.setHours(0, 0, 0, 0);
+
+    if (Number.isNaN(explicitYear) && parsed > today) {
+      year -= 1;
+      parsed = new Date(year, month, day);
+      parsed.setHours(0, 0, 0, 0);
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function getWeekKey(date: Date): string {
+  const startOfWeek = new Date(date);
+  const day = startOfWeek.getDay();
+  const diff = startOfWeek.getDate() - day + (day === 0 ? -6 : 1);
+  startOfWeek.setDate(diff);
+  startOfWeek.setHours(0, 0, 0, 0);
+  return startOfWeek.toISOString().split("T")[0];
+}
+
+function getWeekLabel(weekKey: string): string {
+  const [year, month, day] = weekKey.split("-").map(Number);
+  const startOfWeek = new Date(year, month - 1, day);
+  const endOfWeek = new Date(year, month - 1, day + 6);
+
+  const formatDate = (date: Date) => {
+    const monthName = date.toLocaleString("en-US", { month: "short" });
+    return `${monthName} ${date.getDate()}, ${date.getFullYear()}`;
+  };
+
+  return `${formatDate(startOfWeek)} - ${formatDate(endOfWeek)}`;
+}
+
+export function aggregateRatings(overviewData: OverviewData[]): DailyRatingData[] {
+  return overviewData
+    .map((entry) => ({
+      date: entry.date,
+      rating: parseFloat(entry.r),
+    }))
+    .filter((entry) => entry.date && !Number.isNaN(entry.rating));
+}
+
+export function aggregateSleepData(
+  sleepData: SleepData[],
+  overviewData: OverviewData[],
+): DailySleepAggregate[] {
+  const ratingMap = new Map<string, number>();
+  for (const entry of aggregateRatings(overviewData)) {
+    ratingMap.set(entry.date, entry.rating);
+  }
+
+  return sleepData.map((entry, index) => {
+    const total = parseTimeToMinutes(entry.time);
+    const rem = parseTimeToMinutes(entry.rem);
+    const deep = parseTimeToMinutes(entry.deep);
+    const light = Math.max(0, total - rem - deep);
+
+    return {
+      index,
+      date: entry.date,
+      total,
+      rem,
+      deep,
+      light,
+      score: entry.score,
+      rawRating: ratingMap.get(entry.date) || 0,
+    };
+  });
+}
+
+export function aggregateScreenTimeData(
+  screenTimeData: ScreenTimeData[],
+): DailyScreenTimeAggregate[] {
+  const totals = new Map<string, DailyScreenTimeAggregate>();
+
+  for (const entry of screenTimeData) {
+    if (!entry.date || !entry.duration) continue;
+
+    const category = entry.category || "Other";
+    const key = `${entry.date}\u0000${category}`;
+    const existing = totals.get(key);
+    const minutes = parseTimeToMinutes(entry.duration);
+
+    if (existing) {
+      existing.minutes += minutes;
+    } else {
+      totals.set(key, {
+        date: entry.date,
+        category,
+        minutes,
+      });
+    }
+  }
+
+  return Array.from(totals.values());
+}
+
+export function aggregateWorkoutData(
+  workoutData: WorkoutData[],
+  todayTimestamp: number,
+): WeeklySeriesData[] {
+  const today = new Date(todayTimestamp);
+  today.setHours(0, 0, 0, 0);
+  const weeklyData = new Map<string, WeeklySeriesData>();
+
+  for (const entry of workoutData) {
+    if (!entry.date || !entry.time) continue;
+
+    const parsed = parseSheetDate(entry.date, today);
+    if (!parsed || Number.isNaN(parsed.getTime())) continue;
+
+    const minutes = parseTimeToMinutes(entry.time);
+    if (minutes === 0) continue;
+
+    const type = entry.type || "Other";
+    const week = getWeekKey(parsed);
+    const weekData = weeklyData.get(week) || {
+      week,
+      weekLabel: getWeekLabel(week),
+    };
+
+    weekData[type] = ((weekData[type] as number | undefined) || 0) + minutes;
+    weeklyData.set(week, weekData);
+  }
+
+  return Array.from(weeklyData.values()).sort(
+    (a, b) => new Date(a.week).getTime() - new Date(b.week).getTime(),
+  );
+}
+
+export function aggregateMoneyData(
+  moneyData: MoneyData[],
+  todayTimestamp: number,
+): WeeklySeriesData[] {
+  const today = new Date(todayTimestamp);
+  today.setHours(0, 0, 0, 0);
+  const cutoffDate = new Date("2022-09-01");
+  cutoffDate.setHours(0, 0, 0, 0);
+  const weeklyData = new Map<string, WeeklySeriesData>();
+
+  for (const entry of moneyData) {
+    if (!entry.date || !entry.cad) continue;
+
+    const parsed = parseSheetDate(entry.date, today);
+    if (!parsed || Number.isNaN(parsed.getTime()) || parsed < cutoffDate) {
+      continue;
+    }
+
+    const amount = parseFloat(entry.cad.replace(/[^0-9.-]/g, ""));
+    if (Number.isNaN(amount) || amount === 0) continue;
+
+    const tag = entry.tag || "Other";
+    if (tag === "Investments") continue;
+
+    const week = getWeekKey(parsed);
+    const weekData = weeklyData.get(week) || {
+      week,
+      weekLabel: getWeekLabel(week),
+    };
+
+    weekData[tag] = ((weekData[tag] as number | undefined) || 0) +
+      Math.abs(amount);
+    weeklyData.set(week, weekData);
+  }
+
+  return Array.from(weeklyData.values()).sort(
+    (a, b) => new Date(a.week).getTime() - new Date(b.week).getTime(),
+  );
+}
+
+export function totalScreenTimeMinutes(
+  data: DailyScreenTimeAggregate[],
+  days: number,
+): number {
+  const dates = new Set<string>();
+  let total = 0;
+
+  for (const entry of data) {
+    if (!dates.has(entry.date)) {
+      if (dates.size >= days) break;
+      dates.add(entry.date);
+    }
+
+    if (dates.has(entry.date)) {
+      total += entry.minutes;
+    }
+  }
+
+  return total;
+}
+
+export function totalSleepMinutes(
+  data: DailySleepAggregate[],
+  days: number,
+): number {
+  return data.slice(0, days).reduce((sum, entry) => sum + entry.total, 0);
+}
+
+export { formatDateKey, formatMinutes };

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -1,13 +1,19 @@
 import { PostHog } from "posthog-node";
 
-export default function PostHogClient() {
-  const posthogClient = new PostHog(
-    process.env.NEXT_PUBLIC_POSTHOG_KEY as string,
-    {
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      flushAt: 1,
-      flushInterval: 0,
-    },
-  );
-  return posthogClient;
+type PostHogClient = Pick<PostHog, "shutdown">;
+
+export default function PostHogClient(): PostHogClient {
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+  if (!apiKey) {
+    return {
+      shutdown: async () => undefined,
+    };
+  }
+
+  return new PostHog(apiKey, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0,
+  });
 }

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -7,7 +7,7 @@ const REQUIRED_SCOPES = [
 
 const SERVICE_ACCOUNT_EMAIL = process.env.GOOGLE_CLIENT_EMAIL;
 const SERVICE_ACCOUNT_PRIVATE_KEY = (() => {
-  const raw = process.env.GOOGLE_PRIVATE_KEY as string;
+  const raw = process.env.GOOGLE_PRIVATE_KEY || "";
 
   // Try parsing as-is first (in case env var is clean JSON)
   try {

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -69,6 +69,10 @@ export type FetchSheetRowsOptions = {
 };
 
 async function loadWorksheet(worksheetId: number) {
+  if (!SERVICE_ACCOUNT_EMAIL || !SERVICE_ACCOUNT_PRIVATE_KEY || !SPREADSHEET_ID) {
+    return null;
+  }
+
   const auth = new JWT({
     email: SERVICE_ACCOUNT_EMAIL,
     key: SERVICE_ACCOUNT_PRIVATE_KEY,
@@ -78,7 +82,7 @@ async function loadWorksheet(worksheetId: number) {
   const document = new GoogleSpreadsheet(SPREADSHEET_ID, auth);
   await document.loadInfo();
 
-  return document.sheetsById[worksheetId];
+  return document.sheetsById[worksheetId] || null;
 }
 
 export async function fetchSheetRows(
@@ -87,6 +91,10 @@ export async function fetchSheetRows(
   const worksheetId = options.worksheetId as number;
   const worksheet = await loadWorksheet(worksheetId);
   const { limit } = options;
+
+  if (!worksheet) {
+    return [];
+  }
 
   await worksheet.loadHeaderRow();
   const rows = await worksheet.getRows(limit ? { limit } : undefined);


### PR DESCRIPTION
## Summary
- aggregate private analytics rows on the server before passing props to client components
- remove transaction names/merchants, app/site names, and detailed workout fields from hydrated payloads
- keep charts functional using weekly/category, daily/category, and sleep/rating aggregates

## Validation
- `npx tsc --noEmit`
- `npx eslint app/(main)/analytics/page.tsx components/Analytics/Analytics.tsx components/Analytics/ExpenditureChart.tsx components/Analytics/ProjectsChart.tsx components/Analytics/ScreenTimePieChart.tsx components/Analytics/SleepTrendsChart.tsx components/Analytics/WorkoutsChart.tsx lib/analytics-data.ts`

## Deploy note
After merge/deploy, purge any cached `/analytics` responses so old hydrated payloads are no longer served.
